### PR TITLE
Chatting Room Service 로직 구현

### DIFF
--- a/src/main/java/jungmo/server/domain/entity/ChattingRoom.java
+++ b/src/main/java/jungmo/server/domain/entity/ChattingRoom.java
@@ -1,5 +1,6 @@
 package jungmo.server.domain.entity;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -25,12 +26,14 @@ public class ChattingRoom {
     private Long id;
 
     @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "gathering_id")
+    @JoinColumn(name = "gathering_id", nullable = false)
     private Gathering gathering;
 
+    @Column(nullable = false)
     private LocalDate createdAt;
 
     @Setter
+    @Column(nullable = false)
     private Boolean isDel;
 
     private ChattingRoom(Gathering gathering) {

--- a/src/main/java/jungmo/server/domain/provider/ChattingRoomProvider.java
+++ b/src/main/java/jungmo/server/domain/provider/ChattingRoomProvider.java
@@ -1,0 +1,26 @@
+package jungmo.server.domain.provider;
+
+import jungmo.server.domain.entity.ChattingRoom;
+import jungmo.server.domain.repository.ChattingRoomRepository;
+import jungmo.server.global.error.ErrorCode;
+import jungmo.server.global.error.exception.BusinessException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ChattingRoomProvider {
+
+    private final ChattingRoomRepository chattingRoomRepository;
+
+    public ChattingRoom findChattingRoom(Long gatheringId) {
+
+        ChattingRoom chattingRoom = chattingRoomRepository.findChattingRoomByGatheringId(gatheringId)
+            .orElseThrow(() -> new BusinessException(ErrorCode.CHATTING_ROOM_NOT_EXISTS));
+        if (chattingRoom.getIsDel()) {
+            throw new BusinessException(ErrorCode.CHATTING_ROOM_ALREADY_DELETED);
+        }
+
+        return chattingRoom;
+    }
+}

--- a/src/main/java/jungmo/server/domain/repository/ChattingRoomRepository.java
+++ b/src/main/java/jungmo/server/domain/repository/ChattingRoomRepository.java
@@ -1,0 +1,10 @@
+package jungmo.server.domain.repository;
+
+import java.util.Optional;
+import jungmo.server.domain.entity.ChattingRoom;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ChattingRoomRepository extends JpaRepository<ChattingRoom, Long> {
+
+    Optional<ChattingRoom> findChattingRoomByGatheringId(Long gatheringId);
+}

--- a/src/main/java/jungmo/server/domain/service/ChattingRoomService.java
+++ b/src/main/java/jungmo/server/domain/service/ChattingRoomService.java
@@ -1,0 +1,33 @@
+package jungmo.server.domain.service;
+
+import jungmo.server.domain.entity.ChattingRoom;
+import jungmo.server.domain.entity.Gathering;
+import jungmo.server.domain.provider.ChattingRoomProvider;
+import jungmo.server.domain.repository.ChattingRoomRepository;
+import jungmo.server.global.aop.annotation.CheckWritePermission;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ChattingRoomService {
+
+    private final ChattingRoomRepository chattingRoomRepository;
+    private final ChattingRoomProvider chattingRoomProvider;
+
+    @CheckWritePermission
+    public ChattingRoom saveChattingRoom(Gathering gathering) {
+
+        return chattingRoomRepository.save(ChattingRoom.create(gathering));
+    }
+
+    @CheckWritePermission
+    public void deleteChattingRoom(Long gatheringId) {
+
+        ChattingRoom chattingRoom = chattingRoomProvider.findChattingRoom(gatheringId);
+
+        chattingRoom.setIsDel(true);
+    }
+}

--- a/src/main/java/jungmo/server/domain/service/GatheringService.java
+++ b/src/main/java/jungmo/server/domain/service/GatheringService.java
@@ -43,6 +43,7 @@ public class GatheringService {
     private final GatheringLocationDataProvider gatheringLocationDataProvider;
     private final GatheringLocationRepository gatheringLocationRepository;
     private final GatheringNotificationService gatheringNotificationService;
+    private final ChattingRoomService chattingRoomService;
 
     @Transactional
     public Long saveGathering(GatheringRequest dto) {
@@ -65,7 +66,10 @@ public class GatheringService {
         gatheringUserService.addUsersToGathering(savedGathering, userIds);
         // 만나는 장소와의 매핑, 저장
         GatheringLocation gatheringLocation = gatheringLocationService.saveGatheringLocation(gathering.getId(), dto.getMeetingLocation(), true);
+        // 채팅방 생성
+        ChattingRoom saveChattingRoom = chattingRoomService.saveChattingRoom(savedGathering);
 
+        log.info("ChattingRoom ID: {}", saveChattingRoom.getId());
         log.info("GatheringLocation ID: {}", gatheringLocation.getId());
         log.info("Gathering: {}", gatheringLocation.getGathering());
         log.info("Is initialized: {}", Hibernate.isInitialized(gatheringLocation.getGathering()));
@@ -106,6 +110,8 @@ public class GatheringService {
             if (!existingUserIds.isEmpty()) {  // 모임에 유저가 수정자만 있는 상황을 제외한 나머지경우
                 gatheringNotificationService.delete(existingUserIds, gatheringId);
             }
+
+            chattingRoomService.deleteChattingRoom(gatheringId);    // 채팅방 삭제
 
             gathering.setDeleted(true);
         } else {

--- a/src/main/java/jungmo/server/global/error/ErrorCode.java
+++ b/src/main/java/jungmo/server/global/error/ErrorCode.java
@@ -53,7 +53,12 @@ public enum ErrorCode {
     LOCATION_ALREADY_EXISTS(404, "GL003", "모임에 해당장소가 이미 포함되어 있습니다."),
 
     //Location
-    LOCATION_NOT_EXISTS(404,"L001","해당하는 장소가 존재하지 않습니다");
+    LOCATION_NOT_EXISTS(404,"L001","해당하는 장소가 존재하지 않습니다"),
+
+    //ChattingRoom
+    CHATTING_ROOM_NOT_EXISTS(404, "R001", "해당하는 채팅방이 존재하지 않습니다."),
+    CHATTING_ROOM_ALREADY_DELETED(404, "R002", "이미 삭제된 채팅방입니다.");
+
     private int status;
     private final String code;
     private final String message;


### PR DESCRIPTION
Gathering 모임 생성 시 모임 id 기반 Chatting Room 생성
ErrorCode 추가 : ROO1, ROO2 ( NOT EXISTS, ALREADY_DELETED ) ChattingRoomProvider 구현 : findChattingRoom 메소드 구현
Gathering 모임 삭제 시 Chatting Room 삭제 처리
채팅방 생성 및 삭제 시 어노테이션 활용하여 권한 체크
ChattingRoom Entity Column Not Null 설정
모임 생성 시 같은 트랜잭션에 넣어두었습니다. 채팅방도 자동 생성이기 때문에 채팅방 생성 실패 시 모임 생성 실패하게 두었습니다.